### PR TITLE
Add SqlBuilder order tests

### DIFF
--- a/lib/database/database/sql_builder.dart
+++ b/lib/database/database/sql_builder.dart
@@ -238,17 +238,20 @@ class SqlBuilder {
   /// builder.queryOrder(fields: [['field1', 'ASC'], ['field2', 'DESC']]);
   /// ```
   SqlBuilder queryOrder({List<List<String>> fields = const []}) {
+    if (fields.isEmpty) {
+      return this;
+    }
     List<String> cases = [];
     for (var field in fields) {
-      if (fields.length > 2) {
+      if (field.length > 2) {
         _error +=
             'The order statement must have a maximum of two fields. field (ASC|DESC),)';
         PrintHandler.warningLogger.e(_error);
         throw Exception(_error);
       }
-      cases = [...cases, '${field[0]} ${field[1]}'];
+      cases.add('${field[0]} ${field[1]}');
     }
-    _select.add(cases.join(', '));
+    _select.add('ORDER BY ${cases.join(', ')} ');
     return this;
   }
 

--- a/test/sql_builder_test.dart
+++ b/test/sql_builder_test.dart
@@ -1,0 +1,24 @@
+import 'package:test/test.dart';
+import 'package:sqflite_simple_dao_backend/database/database/sql_builder.dart';
+
+void main() {
+  group('SqlBuilder.queryOrder', () {
+    test('valid input builds expected clause', () {
+      final builder = SqlBuilder()
+          .querySelect()
+          .queryFrom(table: 'table')
+          .queryOrder(fields: [
+        ['col', 'ASC']
+      ]);
+      final sql = builder.build().trim();
+      expect(sql, 'SELECT * FROM table ORDER BY col ASC');
+    });
+
+    test('throws when field list has more than two elements', () {
+      final builder = SqlBuilder();
+      expect(() => builder.queryOrder(fields: [
+            ['col', 'ASC', 'EXTRA']
+          ]), throwsA(isA<Exception>()));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add tests for SqlBuilder.queryOrder
- ensure queryOrder throws for bad field lists and builds ORDER BY clause

## Testing
- `dart test` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684136a595f483258e99348378394402