### PR TITLE
Validate order clause input

### DIFF
--- a/lib/database/database/sql_builder.dart
+++ b/lib/database/database/sql_builder.dart
@@ -239,10 +239,18 @@ class SqlBuilder {
   /// ```
   SqlBuilder queryOrder({List<List<String>> fields = const []}) {
     List<String> cases = [];
+
+    if (fields.length > 2) {
+      _error +=
+          'The order statement accepts a maximum of two fields. Each field must be in the form [\'field\', \'ASC|DESC\']';
+      PrintHandler.warningLogger.e(_error);
+      throw Exception(_error);
+    }
+
     for (var field in fields) {
-      if (fields.length > 2) {
+      if (field.length != 2) {
         _error +=
-            'The order statement must have a maximum of two fields. field (ASC|DESC),)';
+            'Each order entry must follow the format [\'field\', \'ASC|DESC\']';
         PrintHandler.warningLogger.e(_error);
         throw Exception(_error);
       }


### PR DESCRIPTION
## Summary
- add checks for order fields length in SqlBuilder

## Testing
- `dart format --output=none --set-exit-if-changed lib/database/database/sql_builder.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841369a588c8325a0b8f2fad7edfa0a