### PR TITLE
Fix select condition and add tests

### DIFF
--- a/lib/database/database/dao_connector.dart
+++ b/lib/database/database/dao_connector.dart
@@ -552,13 +552,13 @@ class Dao {
       PrintHandler.warningLogger
           .t('⚠️sqflite_simple_dao_backend⚠️: No data found.');
     }
-    if ((T != String ||
-            T != int ||
-            T != double ||
-            T != bool ||
-            T != DateTime ||
-            T == Null) &&
-        model == null) {
+    if (model == null &&
+        T != String &&
+        T != int &&
+        T != double &&
+        T != bool &&
+        T != DateTime &&
+        T != Null) {
       return result;
     } else if (model != null) {
       ClassMirror instance = reflector.reflect(model).type;

--- a/test/dao_connector_test.dart
+++ b/test/dao_connector_test.dart
@@ -1,0 +1,52 @@
+import 'package:test/test.dart';
+import 'package:sqflite_simple_dao_backend/database/database/dao_connector.dart';
+import 'package:sqflite_simple_dao_backend/database/database/sql_builder.dart';
+import 'package:sqflite/sqflite.dart';
+
+class FakeDatabase implements Database {
+  final List<Map<String, Object?>> data;
+  FakeDatabase(this.data);
+
+  @override
+  Future<List<Map<String, Object?>>> rawQuery(String sql, [List<Object?>? arguments]) async {
+    return data;
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class TestDao extends Dao {
+  final Database db;
+  TestDao(this.db);
+
+  @override
+  Future<Database?> getDatabase() async => db;
+}
+
+void main() {
+  group('Dao.select', () {
+    test('returns raw result when no model and non-primitive type', () async {
+      final dao = TestDao(FakeDatabase([
+        {'value': 1}
+      ]));
+      final builder = SqlBuilder.raw(rawSql: 'SELECT value FROM table');
+
+      final result = await dao.select<dynamic>(sqlBuilder: builder);
+
+      expect(result, isA<List<Map<String, Object?>>>());
+    });
+
+    test('returns typed primitives when model is null', () async {
+      final dao = TestDao(FakeDatabase([
+        {'value': 1},
+        {'value': 2},
+      ]));
+      final builder = SqlBuilder.raw(rawSql: 'SELECT value FROM table');
+
+      final result = await dao.select<int>(sqlBuilder: builder);
+
+      expect(result, equals([1, 2]));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- fix conditional logic for `select` result typing
- add unit tests for `Dao.select`

## Testing
- `dart test` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841368c6aa08325aeba6f2226cdc030