### PR TITLE
Fix missing break in dbParameters

### DIFF
--- a/lib/database/params/append.dart
+++ b/lib/database/params/append.dart
@@ -82,6 +82,7 @@ class Append {
           PrintHandler.warningLogger.w(
               'sqflite_simple_dao_backend: In case you want to update the list, just set update = true. 😉');
         }
+        break;
       case 'version':
         if ('${value.runtimeType}'.toLowerCase().contains('int')) {
           DbParameters.dbVersion = value;


### PR DESCRIPTION
## Summary
- fix missing `break` statement in `dbParameters`

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840427bcd2c8325b3502a5330c2f0b8